### PR TITLE
Fix pytest AssertionError

### DIFF
--- a/test/test_models.py
+++ b/test/test_models.py
@@ -281,7 +281,7 @@ def test_add_choice(session):
 
     select_statement = select(models.Choice)
     response = session.execute(select_statement)
-    queried_choice = response.all()
+    queried_choice = [choice for subtpl in response.all() for choice in subtpl]
     [choice1, choice2, choice3].should.equal(queried_choice)
 
 def test_select_choice(session):


### PR DESCRIPTION
response.all from sql statement execution returns a list of tuples, where each tuple has a choice. Need to flatten it to a list of choices for assertion to pass.

`pytest` error was:

```
        select_statement = select(models.Choice)
        response = session.execute(select_statement)
        queried_choice = response.all()
>       [choice1, choice2, choice3].should.equal(queried_choice)

test/test_models.py:285:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <sure.AssertionBuilder object at 0x10c0c40d0>
args = ([(<poll_fighters.models.Choice object at 0x10c0aaf40>,), (<poll_fighters.models.Choice object at 0x10c0b17c0>,), (<poll_fighters.models.Choice object at 0x10c0b1d90>,)],), kw = {}

    @wraps(func)
    def wrapper(self, *args, **kw):
        try:
            value = func(self, *args, **kw)
        except AssertionError as e:
>           raise AssertionError(e)
E           AssertionError: given
E           X = [<poll_fighters.models.Choice object at 0x10c0aaf40>, <poll_fighters.models.Choice object at 0x10c0b17c0>, <poll_fighters.models.Choice object at 0x10c0b1d90>]
E               and
E           Y = [(<poll_fighters.models.Choice object at 0x10c0aaf40>,), (<poll_fighters.models.Choice object at 0x10c0b17c0>,), (<poll_fighters.models.Choice object at 0x10c0b1d90>,)]
E           X[0] is a Choice and Y[0] is a Row instead

/Users/omer/.pyenv/versions/3.9.1/envs/hayden/lib/python3.9/site-packages/sure/__init__.py:387: AssertionError
```


Notice specifically:
```
AssertionError: given
E           X = [<poll_fighters.models.Choice object at 0x10c0aaf40>, <poll_fighters.models.Choice object at 0x10c0b17c0>, <poll_fighters.models.Choice object at 0x10c0b1d90>]
E               and
E           Y = [(<poll_fighters.models.Choice object at 0x10c0aaf40>,), (<poll_fighters.models.Choice object at 0x10c0b17c0>,), (<poll_fighters.models.Choice object at 0x10c0b1d90>,)]
```
The asserted `Y` is a list of tuples. We need to flatten it to match with the asserted `X`